### PR TITLE
Split Rough Spec 

### DIFF
--- a/src/plcc/load_spec/load_rough_spec/load_rough_spec.py
+++ b/src/plcc/load_spec/load_rough_spec/load_rough_spec.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from .parse_rough import parse_rough
 from .parse_includes import Include
+from .split_rough_spec import split_rough_spec
 
 
 class CircularIncludeError(Exception):
@@ -10,13 +11,14 @@ class CircularIncludeError(Exception):
         self.line = line
 
 
-def load_rough(file):
-    return process_includes(
-        load_rough_without_processing_includes(file)
-    )
+def load_rough_spec(file):
+    return split_rough_spec(
+        process_includes(
+            load_rough_spec_without_processing_includes(file)
+    ))
 
 
-def load_rough_without_processing_includes(file):
+def load_rough_spec_without_processing_includes(file):
     def read_file(file):
         with open(file, 'r') as f:
             return f.read()
@@ -27,7 +29,7 @@ def load_rough_without_processing_includes(file):
     )
 
 
-def process_includes(lines, parse_file=load_rough_without_processing_includes):
+def process_includes(lines, parse_file=load_rough_spec_without_processing_includes):
     return IncludeProcessor(parse_file).process(lines)
 
 

--- a/src/plcc/load_spec/load_rough_spec/load_rough_spec_test.py
+++ b/src/plcc/load_spec/load_rough_spec/load_rough_spec_test.py
@@ -1,0 +1,59 @@
+from pytest import raises, mark, fixture
+
+from .parse_lines import Line
+from .parse_blocks import Block
+from .parse_dividers import Divider
+from .load_rough_spec import load_rough_spec
+from .split_rough_spec import RoughSpec, split_rough_spec
+
+
+def test_load_rough_spec(fs):
+    fs.create_file('A.java', contents='hi in java')
+    fs.create_file('B.py', contents='hi in python')
+    fs.create_file('test.py', contents='''\
+one
+%
+two
+% java
+%include /A.java
+% python
+%include /B.py
+% c++
+%%%
+%include nope
+% nope
+%%%
+''')
+    assert load_rough_spec('test.py') == split_rough_spec([
+        makeLine('one', 1, 'test.py'),
+        makeDivider('%', 2, 'test.py'),
+        makeLine('two', 3, 'test.py'),
+        makeDivider('% java', 4, 'test.py'),
+        makeLine('hi in java', 1, '/A.java'),
+        makeDivider('% python', 6, 'test.py'),
+        makeLine('hi in python', 1, '/B.py'),
+        makeDivider('% c++', 8, 'test.py'),
+        makeBlock('''
+            %%%
+            %include nope
+            % nope
+            %%%
+        ''', 9, 12, 'test.py')
+    ])
+
+
+def makeBlockList(string):
+    lines = [makeLine(s) for s in string.strip().split('\n')]
+
+
+def makeLine(string, lineNumber=None, file=None):
+    return Line(string, lineNumber, file)
+
+
+def makeDivider(string, lineNumber=None, file=None):
+    return Divider(makeLine(string, lineNumber, file))
+
+
+def makeBlock(string, startLine, endLine, file=None):
+    return Block([makeLine(s.strip(), num, file) for s, num in zip(string.strip().split('\n'), range(startLine, endLine + 1))])
+

--- a/src/plcc/load_spec/load_rough_spec/split_rough_spec.py
+++ b/src/plcc/load_spec/load_rough_spec/split_rough_spec.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from .parse_lines import Line
+from .parse_dividers import Divider
+from .parse_blocks import Block
+
+
+def split_rough_spec(rough_spec:list) -> RoughSpec:
+    return RoughSpecSplitter().split(rough_spec)
+
+
+@dataclass
+class RoughSpec:
+    lexicalSection: list[Line]
+    syntacticSection: list[Line | Divider]
+    semanticSectionList: list[list[Line | Divider | Block]]
+
+
+class RoughSpecSplitter:
+    def __init__(self):
+        self._roughSpec = None
+        self._sectionList = None
+
+    def split(self, rough_spec:list) -> RoughSpec:
+        self._reset(rough_spec)
+        self._splitElementsIntoSectionsByDividers()
+        return self._makeRoughSpec()
+
+    def _reset(self, rough_spec):
+        self._roughSpec = rough_spec
+        self._sectionList = [[]]
+
+    def _splitElementsIntoSectionsByDividers(self):
+        for el in self._roughSpec:
+            if isinstance(el, Divider):
+                self._sectionList.append([el])
+            else:
+                self._sectionList[-1].append(el)
+
+    def _makeRoughSpec(self):
+        tmpLexical, tmpSyntactic, tmpSemanticList = self._getSections()
+        return RoughSpec(
+            lexicalSection=tmpLexical,
+            syntacticSection=tmpSyntactic,
+            semanticSectionList=tmpSemanticList
+        )
+
+    def _getSections(self):
+        tmpLexical = self._sectionList[0]
+        tmpSyntactic = self._sectionList[1] if len(self._sectionList) > 1 else []
+        tmpSemanticList = self._sectionList[2:] if len(self._sectionList) > 2 else []
+        return tmpLexical, tmpSyntactic, tmpSemanticList

--- a/src/plcc/load_spec/load_rough_spec/split_rough_spec_test.py
+++ b/src/plcc/load_spec/load_rough_spec/split_rough_spec_test.py
@@ -1,0 +1,108 @@
+from pytest import raises, mark, fixture
+
+from .parse_lines import Line
+from .parse_dividers import Divider
+from .load_rough_spec import load_rough_spec
+from .split_rough_spec import RoughSpec, split_rough_spec
+
+
+def test_empty():
+    rough_spec = []
+    expected = RoughSpec(
+        lexicalSection=[],
+        syntacticSection=[],
+        semanticSectionList=[]
+    )
+
+    res = split_rough_spec(rough_spec)
+    assert res == expected
+
+
+def test_no_divider():
+    rough_spec = makeLineList('''
+        one
+        two
+        three
+    ''')
+
+    expected = RoughSpec(
+        lexicalSection=rough_spec[:],
+        syntacticSection=[],
+        semanticSectionList=[]
+    )
+
+    res = split_rough_spec(rough_spec)
+    assert res == expected
+
+
+def test_one_divider():
+    rough_spec = [
+        makeLine('one'),
+        makeDivider('%'),
+        makeLine('two'),
+        makeLine('three')
+    ]
+    expected = RoughSpec(
+        lexicalSection=rough_spec[:1],
+        syntacticSection=rough_spec[1:],
+        semanticSectionList=[]
+    )
+    res = split_rough_spec(rough_spec)
+    assert res == expected
+
+
+def test_three_dividers():
+    rough_spec = [
+        makeLine('one'),
+        makeDivider('%'),
+        makeLine('two'),
+        makeDivider('%'),
+        makeLine('three')
+    ]
+
+    expected = RoughSpec(
+        lexicalSection=rough_spec[0:1],
+        syntacticSection=rough_spec[1:3],
+        semanticSectionList=[
+            rough_spec[3:5]
+        ]
+    )
+
+    res = split_rough_spec(rough_spec)
+    assert res == expected
+
+
+def test_multiple_semantic_sections():
+    rough_spec = [
+        makeLine('one'),
+        makeDivider('%'),
+        makeLine('two'),
+        makeDivider('%'),
+        makeLine('three'),
+        makeDivider('%'),
+        makeLine('four')
+    ]
+
+    expected = RoughSpec(
+        lexicalSection=rough_spec[0:1],
+        syntacticSection=rough_spec[1:3],
+        semanticSectionList=[
+            rough_spec[3:5],
+            rough_spec[5:7]
+        ]
+    )
+
+    res = split_rough_spec(rough_spec)
+    assert res == expected
+
+
+def makeLineList(string):
+    return [makeLine(s.strip()) for s in string.strip().split('\n')]
+
+
+def makeDivider(string):
+    return Divider(makeLine(string))
+
+
+def makeLine(string):
+    return Line(string, None, None)

--- a/src/plcc/load_spec/load_rough_spec/validate_rough_spec.py
+++ b/src/plcc/load_spec/load_rough_spec/validate_rough_spec.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+
+from .parse_lines import Line
+from .parse_dividers import Divider
+from .parse_blocks import Block
+from .split_rough_spec import RoughSpec
+
+
+@dataclass
+class ValidationError:
+    line: Line
+    message: str
+
+
+def validate_rough_spec(rough_spec:RoughSpec):
+    errorList = []
+    errorList.extend(check_no_blocks_in_lexicalSection(rough_spec))
+    errorList.extend(check_no_blocks_in_syntacticSection(rough_spec))
+    return errorList
+
+
+def check_no_blocks_in_lexicalSection(rough_spec:RoughSpec):
+    errorList = []
+    for i in rough_spec.lexicalSection:
+        if isinstance(i, Block):
+            m = f"The lexical section must not have a Block: {i.lines[0]}"
+            errorList.append(ValidationError(line=i.lines[0], message=m))
+    return errorList
+
+
+def check_no_blocks_in_syntacticSection(rough_spec:RoughSpec):
+    errorList = []
+    for i in rough_spec.syntacticSection:
+        if isinstance(i, Block):
+            m = f"The syntactic section must not have a Block: {i.lines[0]}"
+            errorList.append(ValidationError(line=i.lines[0], message=m))
+    return errorList

--- a/src/plcc/load_spec/load_rough_spec/validate_rough_spec_test.py
+++ b/src/plcc/load_spec/load_rough_spec/validate_rough_spec_test.py
@@ -1,0 +1,120 @@
+from pytest import raises, mark, fixture
+
+from .parse_lines import Line
+from .parse_blocks import Block
+from .split_rough_spec import RoughSpec
+from .validate_rough_spec import ValidationError, validate_rough_spec
+
+
+def test_empty_spec_produces_no_errors():
+    spec = makeRoughSpec()
+    errors = validate_rough_spec(spec)
+    assert len(errors) == 0
+
+
+def test_block_in_lexical_section_errors():
+    block = makeEmptyBlock()
+    spec = makeRoughSpec(
+        lexicalSection=[
+            block
+        ]
+    )
+    errors = validate_rough_spec(spec)
+    assert errors[0] == makeLexicalValidationError(block.lines[0])
+
+
+def test_non_blocks_do_not_cause_an_error():
+    block = makeEmptyBlock()
+    spec = makeRoughSpec(
+        lexicalSection=[
+            makeLine('not a block')
+        ],
+        syntacticSection=[
+            makeLine('not a block either')
+        ]
+
+    )
+    errors = validate_rough_spec(spec)
+    assert len(errors) == 0
+
+
+def test_block_in_syntactic_section_errors():
+    block = makeEmptyBlock()
+    spec = makeRoughSpec(
+        syntacticSection=[
+            block
+        ]
+    )
+    errors = validate_rough_spec(spec)
+    assert errors[0] == makeSyntacticValidationError(block.lines[0])
+
+
+def test_block_in_semantic_section_is_NOT_an_error():
+    block = makeEmptyBlock()
+    spec = makeRoughSpec(
+        semanticSectionList=[
+            [ block ]
+        ]
+    )
+    errors = validate_rough_spec(spec)
+    assert len(errors) == 0
+
+
+def test_multiple_errors():
+    block1 = makeEmptyBlock(startNumber=1)
+    block2 = makeEmptyBlock(startNumber=5)
+    block3 = makeEmptyBlock(startNumber=10)
+    spec = makeRoughSpec(
+        lexicalSection=[
+            block1
+        ],
+        syntacticSection=[
+            block2,
+            block3
+        ]
+    )
+    errors = validate_rough_spec(spec)
+    assert errors[0] == makeLexicalValidationError(block1.lines[0])
+    assert errors[1] == makeSyntacticValidationError(block2.lines[0])
+    assert errors[2] == makeSyntacticValidationError(block3.lines[0])
+
+
+def makeEmptyBlock(startNumber=1):
+    return makeBlock(
+        makeLines('''
+            %%%
+            %%%
+        ''', startNumber)
+    )
+
+
+def makeRoughSpec(lexicalSection=None, syntacticSection=None, semanticSectionList=None):
+    lexicalSection = lexicalSection if lexicalSection else []
+    syntacticSection = syntacticSection if syntacticSection else []
+    semanticSectionList = semanticSectionList if semanticSectionList else []
+    return RoughSpec(lexicalSection, syntacticSection, semanticSectionList)
+
+
+def makeLines(string, startNumber=1):
+    numbers = iter(range(startNumber, 100000))
+    return [makeLine(s.strip(), lineNumber=next(numbers)) for s in string.strip().split('\n')]
+
+
+def makeLine(string, lineNumber=1):
+    return Line(string, lineNumber, None)
+
+
+def makeBlock(lines):
+    return Block(lines)
+
+
+def makeLexicalValidationError(line):
+    return makeValidationError('lexical', line)
+
+
+def makeSyntacticValidationError(line):
+    return makeValidationError('syntactic', line)
+
+
+def makeValidationError(section, line):
+    return ValidationError(line, f"The {section} section must not have a Block: {line}")


### PR DESCRIPTION
```
refactor: split and validate rough_spec before parsing

Split the rough_spec into a RoughSpec object that holds attributes for the three distinct sections: lexical, syntactic, and semantic. Add a validation method, which returns a list of ValidationErrors. This will make it easier to parse each individual part later on.

---

* Closes #4
* Closes #12

---

Co-authored-by: Akshar Patel <aksharpatel1233@gmail.com>
Co-authored-by: Stoney Jackson <dr.stoney@gmail.com>

```