### PR TITLE
Add parse_semantic_spec

### DIFF
--- a/src/plcc/load_spec/load_rough_spec/load_rough_spec_test.py
+++ b/src/plcc/load_spec/load_rough_spec/load_rough_spec_test.py
@@ -2,7 +2,7 @@ from pytest import raises, mark, fixture
 
 from .parse_lines import Line
 from .parse_blocks import Block
-from .parse_dividers import Divider
+from .parse_dividers import Divider, parse_dividers
 from .load_rough_spec import load_rough_spec
 from .split_rough_spec import RoughSpec, split_rough_spec
 
@@ -51,8 +51,7 @@ def makeLine(string, lineNumber=None, file=None):
 
 
 def makeDivider(string, lineNumber=None, file=None):
-    return Divider(makeLine(string, lineNumber, file))
-
+    return next(parse_dividers([makeLine(string, lineNumber, file)]))
 
 def makeBlock(string, startLine, endLine, file=None):
     return Block([makeLine(s.strip(), num, file) for s, num in zip(string.strip().split('\n'), range(startLine, endLine + 1))])

--- a/src/plcc/load_spec/load_rough_spec/parse_dividers.py
+++ b/src/plcc/load_spec/load_rough_spec/parse_dividers.py
@@ -7,14 +7,69 @@ from .parse_lines import Line
 
 @dataclass
 class Divider:
+    tool: str
+    language: str
     line: Line
 
+def parse_dividers(lines: list[Line], tool='Java', language='Java') -> list[Divider | Line]:
+    return DividerParser(lines, tool, language).parse()
 
-def parse_dividers(lines, pattern=re.compile(r'^%(?:\s.*)?$'), Divider=Divider):
-    if lines is None:
-        return
-    for line in lines:
-        if isinstance(line, Line) and pattern.match(line.string):
-            yield Divider(line)
+class DividerParser:
+    def __init__(self, lines: list[Line], tool="Java", language="Java"):
+        self.lines = lines
+        self.defaultTool = tool
+        self.defaultLanguage = language
+        self.patterns = self._compilePatterns()
+
+    def parse(self):
+        if not self.lines:
+            return
+        for line in self.lines:
+            yield self._parseDividerLine(line) if self._isLineObject(line) and self._isDividerLine(line.string) else line
+
+    def _parseDividerLine(self,line) -> Divider:
+        matchToolLanguage = self._matchToolLanguage(line.string)
+        matchToolOnly = self._matchToolOnly(line.string)
+        tool = self._getTool(matchToolLanguage, matchToolOnly)
+        language = self._getLanguage(matchToolLanguage, matchToolOnly)
+        return self._createDivider(tool, language, line)
+
+    def _getTool(self, matchToolLanguage, matchToolOnly) -> str:
+        if matchToolLanguage:
+            return matchToolLanguage['tool']
+        elif matchToolOnly:
+            return matchToolOnly['tool']
         else:
-            yield line
+            return self.defaultTool
+
+    def _getLanguage(self, matchToolLanguage, matchToolOnly) -> str:
+        if matchToolLanguage:
+            return matchToolLanguage['language']
+        elif matchToolOnly:
+            return matchToolOnly['tool']
+        else:
+            return self.defaultLanguage
+
+    def _isLineObject(self, line: Line) -> bool:
+        return isinstance(line,Line)
+
+    def _isDividerLine(self, lineStr: str) -> bool:
+        return bool(self.patterns['divider'].match(lineStr))
+
+    def _matchToolLanguage(self, lineStr: str):
+        return self.patterns['toolLanguage'].match(lineStr)
+
+    def _matchToolOnly(self, lineStr):
+        return self.patterns['toolOnly'].match(lineStr)
+
+    def _createDivider(self, tool: str, language: str, line: Line) -> Divider:
+        return Divider(tool=tool, language=language, line=line)
+
+    def _compilePatterns(self) -> dict:
+        return {
+            'divider': re.compile(r'^%(?:\s.*)?$'),
+            'toolLanguage': re.compile(r'^%\s*(?P<tool>\S+)\s(?P<language>\S+).*$'),
+            'toolOnly': re.compile(r'^%\s*(?P<tool>\S+)\s*$')
+        }
+
+

--- a/src/plcc/load_spec/load_rough_spec/parse_dividers_test.py
+++ b/src/plcc/load_spec/load_rough_spec/parse_dividers_test.py
@@ -28,16 +28,33 @@ three
 def test_one_divider():
     lines = list(parse_lines('%'))
     assert list(parse_dividers(lines)) == [
-        Divider(Line('%', 1, None)),
+        make_divider(tool='Java', language='Java', line=lines[0])
     ]
 
 
-def test_one_divider_with_trailing_content():
+def test_one_divider_with_same_language_tool():
     lines = list(parse_lines('% trailing'))
     assert list(parse_dividers(lines)) == [
-        Divider(Line('% trailing', 1, None)),
+        make_divider(tool='trailing', language='trailing', line=lines[0]),
     ]
 
+def test_one_divider_with_different_language_tool():
+    lines = list(parse_lines('% linter python '))
+    assert list(parse_dividers(lines)) == [
+        make_divider(tool='linter', language='python', line=lines[0]),
+    ]
+
+def test_one_divider_with_different_but_same_language_tool():
+    lines = list(parse_lines('% python python'))
+    assert list(parse_dividers(lines)) == [
+        make_divider(tool='python', language='python', line=lines[0]),
+    ]
+
+def test_one_divider_only_takes_first_two_lines():
+    lines = list(parse_lines('% java python c++'))
+    assert list(parse_dividers(lines)) == [
+        make_divider(tool='java', language='python', line=lines[0])
+    ]
 
 def test_two_percents_does_not_match():
     lines = list(parse_lines('%%'))
@@ -50,9 +67,12 @@ def test_blocks_mask_dividers():
     lines = list(parse_blocks(parse_lines('%%%\n%\n%%%')))
     assert list(parse_dividers(lines)) == [
         Block([
-            Line('%%%', 1, None),
-            Line('%', 2, None),
-            Line('%%%', 3, None)
+            lines[0].lines[0],
+            lines[0].lines[1],
+            lines[0].lines[2]
         ])
     ]
+
+def make_divider(tool, language, line):
+    return Divider(tool=tool, language=language, line=line)
 

--- a/src/plcc/load_spec/load_rough_spec/parse_rough_test.py
+++ b/src/plcc/load_spec/load_rough_spec/parse_rough_test.py
@@ -24,13 +24,13 @@ two
 %%%
 ''')) == [
     Line('one', 1, None),
-    Divider(Line('%', 2, None)),
+    Divider(tool='Java', language='Java', line=Line('%', 2, None)),
     Line('two', 3, None),
-    Divider(Line('% java', 4, None)),
+    Divider(tool='java', language='java', line=Line('% java', 4, None)),
     Include(file='/A.java', line=Line('%include /A.java', 5, None)),
-    Divider(Line('% python', 6, None)),
+    Divider(tool='python', language='python', line=Line('% python', 6, None)),
     Include(file='/B.py', line=Line('%include /B.py', 7, None)),
-    Divider(Line('% c++', 8, None)),
+    Divider(tool='c++', language='c++', line=Line('% c++', 8, None)),
     Block([
         Line('%%%', 9, None),
         Line('%include nope', 10, None),

--- a/src/plcc/load_spec/load_rough_spec/split_rough_spec_test.py
+++ b/src/plcc/load_spec/load_rough_spec/split_rough_spec_test.py
@@ -1,7 +1,7 @@
 from pytest import raises, mark, fixture
 
 from .parse_lines import Line
-from .parse_dividers import Divider
+from .parse_dividers import Divider, parse_dividers
 from .load_rough_spec import load_rough_spec
 from .split_rough_spec import RoughSpec, split_rough_spec
 
@@ -101,7 +101,7 @@ def makeLineList(string):
 
 
 def makeDivider(string):
-    return Divider(makeLine(string))
+    return next(parse_dividers([makeLine(string)]))
 
 
 def makeLine(string):

--- a/src/plcc/load_spec/parse_spec/__init__.py
+++ b/src/plcc/load_spec/parse_spec/__init__.py
@@ -6,3 +6,5 @@ from ..load_rough_spec.parse_blocks import Block, parse_blocks, UnclosedBlockErr
 from ..load_rough_spec.parse_includes import Include, parse_includes
 from ..load_rough_spec.parse_dividers import Divider, parse_dividers
 from ..load_rough_spec.parse_rough import parse_rough
+
+from .parse_semantic_spec import parse_semantic_spec, SemanticSpec, CodeFragment, TargetLocator

--- a/src/plcc/load_spec/parse_spec/parse_semantic_spec/__init__.py
+++ b/src/plcc/load_spec/parse_spec/parse_semantic_spec/__init__.py
@@ -1,0 +1,3 @@
+from .parse_semantic_spec import SemanticSpec, parse_semantic_spec
+from .parse_code_fragments import CodeFragment, parse_code_fragments, UndefinedTargetLocatorError, DuplicateTargetLocatorError, CodeFragmentMissingBlockError
+from .parse_target_locator import TargetLocator, parse_target_locator

--- a/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_code_fragments.py
+++ b/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_code_fragments.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+from .parse_target_locator import TargetLocator, parse_target_locator, InvalidTargetLocatorError
+from plcc.load_spec.load_rough_spec.parse_lines import Line
+from plcc.load_spec.load_rough_spec.parse_blocks import Block
+from plcc.load_spec.load_rough_spec.parse_dividers import Divider
+import re
+
+@dataclass
+class CodeFragment:
+    targetLocator: TargetLocator
+    block: Block
+
+def parse_code_fragments(lines_and_blocks: list[Line | Block]):
+    parser = CodeFragmentParser(lines_and_blocks)
+    return parser.parse()
+
+class CodeFragmentParser:
+    def __init__(self, lines_and_blocks: list[Line | Block]):
+        self.lines_and_blocks = lines_and_blocks
+        self.codeFragmentList = []
+        self.targetLocator = None
+        self.targetLocator_regex = r'^(\w+)(?::([a-z]+))?\s*(?:#.*)?$'
+
+    def parse(self):
+        for obj in self.lines_and_blocks:
+            self._parse_line_or_block(obj)
+
+        if self.targetLocator != None:
+            raise CodeFragmentMissingBlockError(self.targetLocator.line)
+
+        return self.codeFragmentList
+
+    def _parse_line_or_block(self, obj):
+        handler = {
+                Line: self._parse_line,
+                Block: self._parse_block
+            }.get(type(obj))
+
+        handler(obj)
+
+
+    def _parse_block(self, block):
+        if self.targetLocator == None:
+            raise UndefinedTargetLocatorError(block.lines[0])
+
+        self.codeFragmentList.append(CodeFragment(targetLocator=self.targetLocator, block=block))
+        self.targetLocator = None
+
+    def _parse_line(self, line):
+        if self._isCommentOrBlank(line.string):
+                return
+
+        if self.targetLocator != None:
+            raise DuplicateTargetLocatorError(line.string)
+        else:
+            if re.match(self.targetLocator_regex, line.string):
+                self.targetLocator = parse_target_locator(line, self.targetLocator_regex)
+            else:
+                raise InvalidTargetLocatorError(line)
+
+
+    def _isCommentOrBlank(self, obj_str):
+        return True if re.match(r'\s*#', obj_str) or re.match(r'\s*$', obj_str) else False
+
+
+class CodeFragmentMissingBlockError(Exception):
+    def __init__(self, line):
+        self.line = line
+
+class UndefinedTargetLocatorError(Exception):
+    def __init__(self, line):
+        self.line = line
+
+class DuplicateTargetLocatorError(Exception):
+    def __init__(self, line):
+        self.line = line

--- a/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_code_fragments_test.py
+++ b/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_code_fragments_test.py
@@ -1,0 +1,61 @@
+from pytest import raises
+from .parse_code_fragments import CodeFragment, parse_code_fragments, UndefinedTargetLocatorError, DuplicateTargetLocatorError, CodeFragmentMissingBlockError
+from .parse_target_locator import TargetLocator, InvalidTargetLocatorError
+from plcc.load_spec.load_rough_spec.parse_blocks import Block
+from plcc.load_spec.load_rough_spec.parse_lines import Line, parse_lines
+
+def test_basic():
+    lines_and_blocks = [make_line('Class:init'), make_block()]
+    assert parse_code_fragments(lines_and_blocks) == [
+        CodeFragment(make_target_locator(lines_and_blocks[0], 'Class', 'init'), make_block())]
+
+def test_consecutive():
+    lines_and_blocks = [make_line('Class:init'), make_block(), make_line('Main'), make_block()]
+    assert parse_code_fragments(lines_and_blocks) == [
+        CodeFragment(make_target_locator(lines_and_blocks[0], 'Class', 'init'), make_block()),
+        CodeFragment(make_target_locator(lines_and_blocks[2], 'Main', None), make_block())]
+
+def test_invalid_target_locator_syntax():
+    lines_and_blocks = [make_line('`'), make_block()]
+    with raises(InvalidTargetLocatorError):
+        parse_code_fragments(lines_and_blocks)
+
+def test_input_must_be_Lines_and_Blocks():
+    invalid_input = ["Only Lines and Dividers Work!", make_line('Class'), make_block()]
+    with raises(TypeError):
+        parse_code_fragments(invalid_input)
+
+def test_blank_lines_ignored():
+    lines = [make_line('Class:init'), make_line('\n'), make_line(''), make_block()]
+    assert parse_code_fragments(lines) == [
+        CodeFragment(make_target_locator(lines[0], 'Class', 'init'), make_block())]
+
+def test_consecutive_target_locators_raise_error():
+    lines_and_blocks = [make_line('Class:init'), make_line('Class:init'), make_block()]
+    with raises(DuplicateTargetLocatorError):
+        parse_code_fragments(lines_and_blocks)
+
+def test_blocks_cannot_be_adjacent():
+    with raises(UndefinedTargetLocatorError):
+      parse_code_fragments([make_line('Class:init'), make_block(), make_block()])
+
+def test_target_locator_without_block_raise_error():
+    with raises(CodeFragmentMissingBlockError):
+        parse_code_fragments([make_line('Class:init')])
+
+def test_block_must_have_target_locator():
+    with raises(UndefinedTargetLocatorError):
+        parse_code_fragments([make_block()])
+
+def make_target_locator(line, className, modifier):
+    return TargetLocator(line, className, modifier)
+
+def make_block():
+    return  Block(list(parse_lines('''\
+%%%
+block
+%%%
+''')))
+
+def make_line(string, number=1, file=None):
+    return Line(string, number, file)

--- a/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_semantic_spec.py
+++ b/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_semantic_spec.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from .parse_code_fragments import CodeFragment, parse_code_fragments
+from plcc.load_spec.load_rough_spec.parse_lines import Line
+from plcc.load_spec.load_rough_spec.parse_blocks import Block
+from plcc.load_spec.load_rough_spec.parse_dividers import Divider
+import re
+
+@dataclass
+class SemanticSpec:
+    language: str
+    tool: str
+    codeFragmentList: [CodeFragment]
+
+def parse_semantic_spec(semantic_spec: list[Divider | Line | Block]) -> SemanticSpec:
+    divider = semantic_spec[0]
+    codeFragmentList = parse_code_fragments(semantic_spec[1:])
+    return SemanticSpec(language = divider.language, tool = divider.tool, codeFragmentList=codeFragmentList)
+

--- a/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_semantic_spec_test.py
+++ b/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_semantic_spec_test.py
@@ -1,0 +1,36 @@
+from pytest import raises
+from .parse_semantic_spec import parse_semantic_spec, parse_code_fragments
+from plcc.load_spec.load_rough_spec.parse_lines import Line, parse_lines
+from plcc.load_spec.load_rough_spec.parse_blocks import Block
+from plcc.load_spec.load_rough_spec.parse_dividers import Divider
+
+def test_basic():
+    lines_divider_and_blocks = [make_divider('Java', 'Java', make_line('%')), make_line('Class:init'), make_block()]
+    semantic_spec = parse_semantic_spec(lines_divider_and_blocks)
+    assert semantic_spec.language, semantic_spec.tool == 'Java'
+    assert semantic_spec.codeFragmentList == parse_code_fragments(lines_divider_and_blocks[1:])
+
+def test_empty_list():
+    with raises(IndexError):
+        parse_semantic_spec([])
+
+def test_no_CodeFragments():
+    list_with_Divider = [make_divider('Java', 'Java', make_line('%'))]
+    semantic_spec = parse_semantic_spec(list_with_Divider)
+    assert semantic_spec.codeFragmentList == []
+    assert semantic_spec.language, semantic_spec.tool == 'Java'
+
+def make_block():
+    return  Block(list(parse_lines('''\
+%%%
+block
+%%%
+''')))
+
+def make_divider(tool, language, line):
+    return Divider(tool=tool, language=language, line=line)
+
+def make_line(string, number=1, file=None):
+    return Line(string, number, file)
+
+

--- a/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_target_locator.py
+++ b/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_target_locator.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from plcc.load_spec.load_rough_spec.parse_lines import Line
+import re
+
+@dataclass
+class TargetLocator:
+    line: Line
+    className: str
+    modifier: str = None
+
+def parse_target_locator(line, regex=r'^(\w+)(?::([a-z]+))?\s*(?:#.*)?$'):
+    match = re.match(regex, line.string)
+    if match:
+        name, modifier = match.group(1), match.group(2) or None
+        return TargetLocator(line = line, className=name, modifier=modifier)
+    raise InvalidTargetLocatorError(line)
+
+class InvalidTargetLocatorError(Exception):
+    def __init__(self, line):
+        self.line = line

--- a/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_target_locator_test.py
+++ b/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_target_locator_test.py
@@ -1,0 +1,28 @@
+from pytest import raises
+from .parse_target_locator import TargetLocator, parse_target_locator, InvalidTargetLocatorError
+from plcc.load_spec.load_rough_spec.parse_lines import Line, parse_lines
+
+def test_ignore_EOL_comments():
+    line = make_line('Class:init #comment')
+    assert parse_target_locator(line) == TargetLocator(line, 'Class', 'init')
+
+def test_requires_colon():
+    with raises(InvalidTargetLocatorError):
+        targetLocator = parse_target_locator(make_line('Class init'))
+
+def test_modifier():
+    lines = [make_line('Class:init'), make_line('Class:modifier')]
+    assert parse_target_locator(lines[0]) == TargetLocator(lines[0], 'Class', 'init')
+    assert parse_target_locator(lines[1]) == TargetLocator(lines[1], 'Class', 'modifier')
+
+def test_empty_line_raises_error():
+    with raises(InvalidTargetLocatorError):
+        parse_target_locator(make_line(''))
+
+def test_className():
+    lines = [make_line('Class'), make_line('name')]
+    assert parse_target_locator(lines[0]) == TargetLocator(lines[0], 'Class', None)
+    assert parse_target_locator(lines[1]) == TargetLocator(lines[1], 'name', None)
+
+def make_line(string, number=1, file=None):
+    return Line(string, number, file)

--- a/src/plcc/load_spec/parse_spec/parse_syntactic_spec/parse_syntactic_spec_test.py
+++ b/src/plcc/load_spec/parse_spec/parse_syntactic_spec/parse_syntactic_spec_test.py
@@ -12,7 +12,7 @@ from .structs import (
     Symbol,
 )
 from plcc.load_spec.load_rough_spec.parse_lines import Line
-from plcc.load_spec.load_rough_spec.parse_dividers import Divider
+from plcc.load_spec.load_rough_spec.parse_dividers import Divider, parse_dividers
 
 
 def test_None_yields_nothing():
@@ -372,7 +372,7 @@ def test_malformed_bnf_raises():
 
 
 def makeDivider(string="%", lineNumber=0, file=""):
-    return Divider(makeLine(string, lineNumber, file))
+    return parse_dividers([makeLine(string, lineNumber, file)])
 
 
 def makeLine(string, lineNumber=0, file: str = ""):


### PR DESCRIPTION
```
feat: add parse_semantic_spec

Parses a given semantic spec into a SemanticSpec object. Updated a Divider object to include tool and language.

---

* Closes #7 

---

Co-authored-by: Michael Banerjee <michaelbanerjee10@gmail.com>
Co-authored-by: Akshar Patel <aksharpatel1233@gmail.com>
Co-authored-by: Kyle Almeida <almeidakyle03@gmail.com>
```