### PR TITLE
feat: add lexical validator

### DIFF
--- a/src/plcc/load_spec/parse_spec/__init__.py
+++ b/src/plcc/load_spec/parse_spec/__init__.py
@@ -2,9 +2,6 @@ from .parse_syntactic_spec import parse_syntactic_spec
 from .parse_lexical_spec import parse_lexical_spec
 
 from ..load_rough_spec.parse_lines import Line, parse_lines
-from ..load_rough_spec.parse_blocks import Block, parse_blocks, UnclosedBlockError
-from ..load_rough_spec.parse_includes import Include, parse_includes
-from ..load_rough_spec.parse_dividers import Divider, parse_dividers
 from ..load_rough_spec.parse_rough import parse_rough
 
 from .parse_semantic_spec import parse_semantic_spec, SemanticSpec, CodeFragment, TargetLocator

--- a/src/plcc/load_spec/validate_spec/validate_lexical_spec/__init__.py
+++ b/src/plcc/load_spec/validate_spec/validate_lexical_spec/__init__.py
@@ -1,0 +1,8 @@
+from .validate_lexical_spec import validate_lexical_spec
+
+from ...parse_spec.parse_lexical_spec import parse_lexical_spec, LexicalRule, LexicalSpec
+from ...load_rough_spec.parse_lines import Line, parse_lines
+from ...load_rough_spec.parse_blocks import Block, parse_blocks, UnclosedBlockError
+from ...load_rough_spec.parse_includes import Include, parse_includes
+from ...load_rough_spec.parse_dividers import Divider, parse_dividers
+from ...load_rough_spec.parse_rough import parse_rough

--- a/src/plcc/load_spec/validate_spec/validate_lexical_spec/lexical_errors.py
+++ b/src/plcc/load_spec/validate_spec/validate_lexical_spec/lexical_errors.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from ...load_rough_spec.parse_lines import Line
+
+
+@dataclass
+class ValidationError:
+    line: Line
+    message: str
+
+@dataclass
+class InvalidNameFormatError(ValidationError):
+    def __init__(self, rule):
+        self.line = rule.line
+        self.message = f"Invalid name format for rule '{rule.name}' (Must be uppercase letters, numbers, and underscores, and cannot start with a number) on line: {rule.line.number}"
+
+@dataclass
+class DuplicateNameError(ValidationError):
+    def __init__(self, rule):
+        self.line = rule.line
+        self.message = f"Duplicate rule name found '{rule.name}' on line: {rule.line.number}"
+
+@dataclass
+class InvalidPatternError(ValidationError):
+    def __init__(self, rule):
+        self.line = rule.line
+        self.message = f"Invalid pattern format found '{rule.pattern}' on line: {rule.line.number} (Patterns can not contain closing closing quotes)"
+
+@dataclass
+class InvalidRuleError(ValidationError):
+    def __init__(self, line):
+        self.line = line
+        self.message = f"Invalid rule format found on line: {line.number}"

--- a/src/plcc/load_spec/validate_spec/validate_lexical_spec/validate_lexical_spec.py
+++ b/src/plcc/load_spec/validate_spec/validate_lexical_spec/validate_lexical_spec.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+import re
+from ...load_rough_spec.parse_lines import Line
+from ...parse_spec.parse_lexical_spec import LexicalSpec, LexicalRule
+from .lexical_errors import ValidationError, InvalidNameFormatError, DuplicateNameError, InvalidPatternError, InvalidRuleError
+
+def validate_lexical_spec(lexicalSpec: LexicalSpec):
+    return LexicalValidator(lexicalSpec).validate()
+
+class LexicalValidator:
+    def __init__(self, lexicalSpec: LexicalSpec):
+        self.lexicalSpec = lexicalSpec
+        self.errorList = []
+        self.names = set()
+        self.patterns = set()
+        self.namePattern = re.compile(r'^[A-Z_][A-Z0-9_]*$')
+
+    def validate(self) -> list:
+        if self._isSpecEmpty():
+            return self.errorList
+        for rule in self.lexicalSpec.ruleList:
+            self._handle(rule)
+        return self.errorList
+
+    def _isSpecEmpty(self):
+        return not (self.lexicalSpec and self.lexicalSpec.ruleList)
+
+    def _handle(self, rule: LexicalRule | Line):
+        if isinstance(rule, LexicalRule):
+            self._checkNameFormat(rule)
+            self._checkDuplicateNames(rule)
+            self._checkPatternFormat(rule)
+        else:
+            self._checkForLine(rule)
+
+    def _checkNameFormat(self, rule: LexicalRule):
+        if not self.namePattern.match(rule.name):
+            self.errorList.append(InvalidNameFormatError(rule=rule))
+
+    def _checkDuplicateNames(self, rule: LexicalRule):
+        if rule.name in self.names:
+            self.errorList.append(DuplicateNameError(rule=rule))
+        else:
+            self.names.add(rule.name)
+
+    def _checkPatternFormat(self, rule: LexicalRule):
+        if "\'" in rule.pattern or "\"" in rule.pattern or rule.pattern == '':
+            self.errorList.append(InvalidPatternError(rule=rule))
+
+    def _checkForLine(self, line: Line):
+        self.errorList.append(InvalidRuleError(line=line))

--- a/src/plcc/load_spec/validate_spec/validate_lexical_spec/validate_lexical_spec_test.py
+++ b/src/plcc/load_spec/validate_spec/validate_lexical_spec/validate_lexical_spec_test.py
@@ -1,0 +1,143 @@
+from pytest import raises, mark, fixture
+
+from ...load_rough_spec.parse_lines import Line
+from .validate_lexical_spec import ValidationError, validate_lexical_spec
+from ...parse_spec.parse_lexical_spec import LexicalRule, LexicalSpec
+from .lexical_errors import ValidationError, InvalidNameFormatError, DuplicateNameError, InvalidPatternError, InvalidRuleError
+
+def test_empty_no_errors():
+    lexicalSpec = makeLexicalSpec([])
+    errors = validate_lexical_spec(lexicalSpec)
+    assert len(errors) == 0
+
+def test_None_no_errors():
+    lexicalSpec = makeLexicalSpec(None)
+    errors = validate_lexical_spec(lexicalSpec)
+    assert len(errors) == 0
+
+def test_lowercase_name_format_error():
+    assertInvalidName("invalid_name")
+
+def test_whitespace_name_format_error():
+    assertInvalidName("NAME ERROR")
+
+def test_empty_name_format_error():
+    assertInvalidName("")
+
+def test_invalid_character_format_error():
+    assertInvalidName("TE$T")
+
+def test_name_start_with_number_format_error():
+    assertInvalidName("1WHITESPACE")
+
+def test_valid_name_no_error():
+    assertValidName("TEST")
+
+def test_duplicate_names_duplicate_error():
+    validName = "VALID"
+    duplicateName = validName
+    assertDuplicationError(validName, duplicateName)
+
+def test_unique_names_no_error():
+    validName = "VALID"
+    otherValidName = "VALID_2"
+    assertNoDuplicationError(validName, otherValidName)
+
+def test_line_invalid_rule_error():
+    assertInvalidRule("gibberish with no pattern or token")
+
+def test_rule_followed_by_line_invalid_rule_error():
+    assertInvalidRule("TEST \'\\w+\' there is nothing useful here")
+
+def test_closing_quotes_pattern_is_an_error():
+    assertInvalidPattern("\"")
+
+def test_closing_quotes_anywhere_in_pattern_is_an_error():
+    assertInvalidPattern("+\"+")
+
+def test_pattern_cant_be_empty():
+    assertInvalidPattern("")
+
+def test_pattern_cant_be_quote_with_whitespace():
+    assertInvalidPattern(" ' ")
+
+def test_multiple_errors_all_counted():
+    validName = makeLexicalRule(name="NAME")
+    invalidName = makeLexicalRule(name="name")
+    duplicateName = validName
+    line = makeLine("no rules here")
+    invalidPattern = makeLexicalRule(pattern="+\"+")
+    lexicalSpec = makeLexicalSpec([validName, invalidName, duplicateName, line, invalidPattern])
+    errors = validate_lexical_spec(lexicalSpec)
+    assert len(errors) == 4
+    assert errors[0] == makeInvalidNameFormatError(invalidName)
+    assert errors[1] == makeDuplicateNameError(duplicateName)
+    assert errors[2] == makeInvalidRuleError(line)
+    assert errors[3] == makeInvalidPatternError(invalidPattern)
+
+def makeLexicalSpec(ruleList=None):
+    return LexicalSpec(ruleList)
+
+def makeLexicalRule(name='TEST', pattern='TEST'):
+    return LexicalRule(makeLine('TEST'), False, name, pattern)
+
+def makeLine(string, lineNumber=1, file=None):
+    return Line(string, lineNumber, file)
+
+def makeLexicalSpecWithOneTokenRule(name='TEST', pattern='TEST'):
+    invalidName = makeLexicalRule(name=name, pattern=pattern)
+    lexicalSpec = makeLexicalSpec([invalidName])
+    return lexicalSpec
+
+def makeLexicalSpecWithTwoTokenRules(name1, name2):
+    validName = makeLexicalRule(name=name1)
+    duplicateName = makeLexicalRule(name=name2)
+    lexicalSpec = makeLexicalSpec([validName, duplicateName])
+    return lexicalSpec
+
+def makeInvalidNameFormatError(rule):
+    return InvalidNameFormatError(rule=rule)
+
+def makeDuplicateNameError(rule):
+    return DuplicateNameError(rule=rule)
+
+def makeInvalidPatternError(rule):
+    return InvalidPatternError(rule=rule)
+
+def makeInvalidRuleError(line):
+    return InvalidRuleError(line=line)
+
+def assertInvalidName(givenName: str):
+    lexicalSpec = makeLexicalSpecWithOneTokenRule(name=givenName)
+    errors = validate_lexical_spec(lexicalSpec)
+    assert len(errors) == 1
+    assert errors[0] == makeInvalidNameFormatError(lexicalSpec.ruleList[0])
+
+def assertValidName(givenName: str):
+    lexicalSpec = makeLexicalSpecWithOneTokenRule(name=givenName)
+    errors = validate_lexical_spec(lexicalSpec)
+    assert len(errors) == 0
+
+def assertInvalidPattern(givenPattern: str):
+    lexicalSpec = makeLexicalSpecWithOneTokenRule(pattern=givenPattern)
+    errors = validate_lexical_spec(lexicalSpec)
+    assert len(errors) == 1
+    assert errors[0] == makeInvalidPatternError(lexicalSpec.ruleList[0])
+
+def assertInvalidRule(lineStr: str):
+    line = makeLine(lineStr)
+    lexicalSpec = makeLexicalSpec([line])
+    errors = validate_lexical_spec(lexicalSpec)
+    assert len(errors) == 1
+    assert errors[0] == makeInvalidRuleError(line)
+
+def assertDuplicationError(givenName1: str, givenName2: str):
+    lexicalSpec = makeLexicalSpecWithTwoTokenRules(name1=givenName1, name2=givenName2)
+    errors = validate_lexical_spec(lexicalSpec)
+    assert len(errors) == 1
+    assert errors[0] == makeDuplicateNameError(lexicalSpec.ruleList[0])
+
+def assertNoDuplicationError(givenName1: str, givenName2: str):
+    lexicalSpec = makeLexicalSpecWithTwoTokenRules(name1=givenName1, name2=givenName2)
+    errors = validate_lexical_spec(lexicalSpec)
+    assert len(errors) == 0


### PR DESCRIPTION
Squashed Commit Message:
```
feat: add lexical validator

Validates a given LexicalSpec object and returns an errorList

---

* Closes #13 

---

Co-authored-by: Kyle Almeida <almeidakyle03@gmail.com>
Co-authored-by: Akshar Patel <aksharpatel1233@gmail.com>
```