### PR TITLE
validate syntactic section

### DIFF
--- a/src/plcc/load_spec/parse_spec/parse_syntactic_spec/structs.py
+++ b/src/plcc/load_spec/parse_spec/parse_syntactic_spec/structs.py
@@ -61,6 +61,8 @@ class RepeatingSyntacticRule(SyntacticRule):
 
 @dataclass
 class SyntacticSpec(list):
+    def __init__(self, rules=None):
+        if rules: super(rules)
     pass
 
 

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/__init__.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/__init__.py
@@ -1,0 +1,18 @@
+from .validate_syntactic_spec import validate_syntactic_spec
+
+from ...parse_spec.parse_syntactic_spec import (
+    parse_syntactic_spec,
+    SyntacticSpec,
+    SyntacticRule,
+)
+
+from .errors import (
+    ValidationError,
+    InvalidLhsNameError,
+    InvalidLhsAltNameError,
+    DuplicateLhsError,
+)
+from ...load_rough_spec.parse_lines import Line, parse_lines
+from ...load_rough_spec.parse_includes import Include, parse_includes
+from ...load_rough_spec.parse_dividers import Divider, parse_dividers
+from ...load_rough_spec.parse_rough import parse_rough

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/errors.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/errors.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ValidationError:
+    def __init__(self, rule):
+        self.rule = rule
+
+
+@dataclass
+class InvalidLhsNameError(ValidationError):
+    def __init__(self, rule):
+        super().__init__(rule)
+        self.message = f"Invalid LHS name format for rule: '{
+            rule.line.string}' (must start with a lower-case letter, and may contain upper or lower case letters, numbers and/or underscore) on line: {rule.line.number}"
+
+
+@dataclass
+class InvalidLhsAltNameError(ValidationError):
+    def __init__(self, rule):
+        super().__init__(rule)
+        self.message = f"Invalid LHS alternate name format for rule: '{
+            rule.line.string}' (must start with a upper-case letter, and may contain upper or lower case letters, numbers and/or underscore) on line: {rule.line.number}"
+
+
+@dataclass
+class DuplicateLhsError(ValidationError):
+    def __init__(self, rule):
+        super().__init__(rule)
+        self.message = f"Duplicate lhs name: '{
+                rule.line.string}' on line: {rule.line.number}"

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_lhs.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_lhs.py
@@ -1,0 +1,66 @@
+import re
+from ...parse_spec.parse_syntactic_spec import (
+    SyntacticSpec,
+)
+from .errors import (
+    InvalidLhsNameError,
+    InvalidLhsAltNameError,
+    DuplicateLhsError,
+    ValidationError,
+)
+
+
+def validate_lhs(syntacticSpec: SyntacticSpec):
+    return SyntacticLhsValidator(syntacticSpec.copy()).validate()
+
+
+class SyntacticLhsValidator:
+    spec: SyntacticSpec
+
+    def __init__(self, syntacticSpec: SyntacticSpec):
+        self.spec = syntacticSpec
+        self.errorList = []
+        self.nonTerminals = set()
+
+    def validate(self) -> tuple[list[ValidationError], set[str]]:
+        while len(self.spec) > 0:
+            self.rule = self.spec.pop(0)
+            self._checkLine()
+        return self.errorList, self.nonTerminals
+
+    def _checkLine(self):
+        name, alt_name = self._getNames()
+        self._checkName(name)
+        if alt_name:
+            self._checkAltName(alt_name)
+        self._checkDuplicates()
+
+    def _getNames(self) -> tuple[str, str]:
+        return (self.rule.lhs.name, self.rule.lhs.altName)
+
+    def _checkName(self, name: str):
+        if not re.match(r"^[a-z][a-zA-Z0-9_]+$", name):
+            self._appendInvalidLhsNameError()
+
+    def _checkAltName(self, alt_name: str):
+        if not re.match(r"^[A-Z][a-zA-Z0-9_]+$", alt_name):
+            self._appendInvalidLhsAltNameError()
+
+    def _getResolvedName(self) -> str:
+        name, alt_name = self._getNames()
+        return alt_name if alt_name else name.capitalize()
+
+    def _checkDuplicates(self):
+        name = self._getResolvedName()
+        if name in self.nonTerminals:
+            self._appendDuplicateLhsError()
+        self.nonTerminals.add(name)
+
+    def _appendInvalidLhsNameError(self):
+        self.errorList.append(InvalidLhsNameError(self.rule))
+
+    def _appendInvalidLhsAltNameError(self):
+        self.errorList.append(InvalidLhsAltNameError(self.rule))
+
+    def _appendDuplicateLhsError(self):
+        self.errorList.append(DuplicateLhsError(self.rule))

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_rhs.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_rhs.py
@@ -1,0 +1,18 @@
+from ...parse_spec.parse_syntactic_spec import (
+    SyntacticSpec,
+)
+
+
+def validate_rhs(syntacticSpec: SyntacticSpec):
+    return SyntacticRhsValidator(syntacticSpec).validate()
+
+
+class SyntacticRhsValidator:
+    spec: SyntacticSpec
+
+    def __init__(self, syntacticSpec: SyntacticSpec):
+        self.spec = syntacticSpec
+        self.errorList = []
+
+    def validate(self):
+        pass

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_syntactic_spec.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_syntactic_spec.py
@@ -1,0 +1,35 @@
+from ...parse_spec.parse_syntactic_spec import (
+    SyntacticSpec,
+    SyntacticRule,
+)
+from .validate_lhs import validate_lhs
+from .validate_rhs import validate_rhs
+
+
+def validate_syntactic_spec(syntacticSpec: SyntacticSpec):
+    return SyntacticValidator(syntacticSpec).validate()
+
+
+class SyntacticValidator:
+    syntacticSpec: SyntacticSpec
+    rule: SyntacticRule
+
+    def __init__(self, syntacticSpec: SyntacticSpec):
+        self.syntacticSpec = syntacticSpec
+        self.errorList = []
+        self.nonTerminals = set()
+
+    def validate(self) -> list:
+        if not self.syntacticSpec:
+            return self.errorList
+        self._validateLhs()
+        return self.errorList
+
+    def _validateLhs(self):
+        lhs_error_list, non_terminal_set = validate_lhs(self.syntacticSpec)
+        if lhs_error_list:
+            self.errorList = lhs_error_list
+        self.nonTerminals = non_terminal_set
+
+    def _validateRhs(self):
+        _ = validate_rhs(self.syntacticSpec)

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_syntactic_spec_test.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_syntactic_spec_test.py
@@ -1,0 +1,206 @@
+from pytest import raises, mark, fixture
+from typing import List
+
+from ...load_rough_spec.parse_lines import Line
+from .validate_syntactic_spec import validate_syntactic_spec
+from ...parse_spec.parse_syntactic_spec import (
+    SyntacticRule,
+    SyntacticSpec,
+    Symbol,
+    LhsNonTerminal,
+    Terminal,
+)
+from .errors import (
+    InvalidLhsNameError,
+    InvalidLhsAltNameError,
+    DuplicateLhsError,
+)
+
+
+def test_empty_no_errors():
+    syntacticSpec = makeSyntacticSpec([])
+    errors = validate_syntactic_spec(syntacticSpec)
+    assert len(errors) == 0
+
+
+def test_None_no_errors():
+    syntacticSpec = makeSyntacticSpec(None)
+    errors = validate_syntactic_spec(syntacticSpec)
+    assert len(errors) == 0
+
+
+def test_valid_line_no_errors():
+    valid_line = makeLine("<sentence> ::= WORD")
+    errors = validate_syntactic_spec(
+        [
+            makeSyntacticRule(
+                valid_line, makeLhsNonTerminal("sentence"), [makeTerminal("WORD")]
+            )
+        ]
+    )
+    assert len(errors) == 0
+
+
+def test_distinct_resolved_name():
+    line_answer = makeSyntacticRule(
+        makeLine("<sentence>:Answer ::= VERB"),
+        makeLhsNonTerminal("sentence", "Answer"),
+        [makeTerminal("VERB")],
+    )
+    line_question = makeSyntacticRule(
+        makeLine("<sentence>:Question ::= WORD"),
+        makeLhsNonTerminal("sentence", "Question"),
+        [makeTerminal("WORD")],
+    )
+    errors = validate_syntactic_spec([line_answer, line_question])
+    assert len(errors) == 0
+
+
+def test_valid_lhs_alt_name():
+    valid_line = makeLine("<sentence>:Name_Version_1 ::= WORD")
+    errors = validate_syntactic_spec(
+        [
+            makeSyntacticRule(
+                valid_line,
+                makeLhsNonTerminal("sentence", "Name_Version_1"),
+                [makeTerminal("WORD")],
+            )
+        ]
+    )
+    assert len(errors) == 0
+
+
+def test_number_lhs_terminal():
+    invalid_nonterminal = makeLine("<1sentence> ::= WORD")
+    spec = [
+        makeSyntacticRule(
+            invalid_nonterminal, makeLhsNonTerminal("1sentence"), [makeTerminal("WORD")]
+        )
+    ]
+    errors = validate_syntactic_spec(spec)
+    assert len(errors) == 1
+    assert errors[0] == makeInvalidLhsNameFormatError(spec[0])
+
+
+def test_capital_lhs_terminal():
+    capital_lhs_name = makeLine("<Sentence> ::= WORD")
+    spec = [
+        makeSyntacticRule(
+            capital_lhs_name, makeLhsNonTerminal("Sentence"), [makeTerminal("WORD")]
+        )
+    ]
+    errors = validate_syntactic_spec(spec)
+    assert len(errors) == 1
+    assert errors[0] == makeInvalidLhsNameFormatError(spec[0])
+
+
+def test_undercase_lhs_alt_name():
+    invalid_alt_name = makeLine("<sentence>:name ::= WORD")
+    spec = [
+        makeSyntacticRule(
+            invalid_alt_name,
+            makeLhsNonTerminal("sentence", "name"),
+            [makeTerminal("WORD")],
+        )
+    ]
+    errors = validate_syntactic_spec(spec)
+    assert len(errors) == 1
+    assert errors[0] == makeInvalidLhsAltNameFormatError(spec[0])
+
+
+def test_underscore_lhs_alt_name():
+    invalid_alt_name = makeLine("<sentence>:_name ::= WORD")
+    spec = [
+        makeSyntacticRule(
+            invalid_alt_name,
+            makeLhsNonTerminal("sentence", "_name"),
+            [makeTerminal("WORD")],
+        )
+    ]
+    errors = validate_syntactic_spec(spec)
+    assert len(errors) == 1
+    assert errors[0] == makeInvalidLhsAltNameFormatError(spec[0])
+
+
+def test_duplicate_lhs_name():
+    lhs_sentence = makeLhsNonTerminal("sentence")
+    rule_1 = makeSyntacticRule(
+        makeLine("<sentence> ::= VERB"),
+        lhs_sentence,
+        [makeTerminal("VERB")],
+    )
+    rule_2 = makeSyntacticRule(
+        makeLine("<sentence> ::= WORD"),
+        lhs_sentence,
+        [makeTerminal("WORD")],
+    )
+    spec = [rule_1, rule_2]
+    errors = validate_syntactic_spec(spec)
+    assert len(errors) == 1
+    assert errors[0] == makeDuplicateLhsError(spec[1])
+
+
+def test_duplicate_lhs_alt_name():
+    rule_1 = makeSyntacticRule(
+        makeLine("<sentence>:Name ::= VERB"),
+        makeLhsNonTerminal("sentence", "Name"),
+        [makeTerminal("VERB")],
+    )
+    rule_2 = makeSyntacticRule(
+        makeLine("<sentence>:Name ::= WORD"),
+        makeLhsNonTerminal("sentence", "Name"),
+        [makeTerminal("WORD")],
+    )
+    spec = [rule_1, rule_2]
+    errors = validate_syntactic_spec(spec)
+    assert len(errors) == 1
+    assert errors[0] == makeDuplicateLhsError(spec[1])
+
+
+def test_duplicate_resolved_name():
+    alt_name = makeSyntacticRule(
+        makeLine("<sentence>:Name ::= VERB"),
+        makeLhsNonTerminal("sentence", "Name"),
+        [makeTerminal("VERB")],
+    )
+    non_terminal_name = makeSyntacticRule(
+        makeLine("<name> ::= WORD"),
+        makeLhsNonTerminal("name"),
+        [makeTerminal("WORD")],
+    )
+    spec = [alt_name, non_terminal_name]
+    errors = validate_syntactic_spec(spec)
+    assert len(errors) == 1
+    assert errors[0] == makeDuplicateLhsError(spec[1])
+
+
+def makeSyntacticSpec(ruleList=None):
+    return SyntacticSpec(ruleList)
+
+
+def makeSyntacticRule(line: Line, lhs: LhsNonTerminal, rhsList: List[Symbol]):
+    return SyntacticRule(line, lhs, rhsList)
+
+
+def makeLine(string, lineNumber=1, file=None):
+    return Line(string, lineNumber, file)
+
+
+def makeLhsNonTerminal(name: str | None, altName: str | None = None):
+    return LhsNonTerminal(name, altName)
+
+
+def makeTerminal(name: str | None):
+    return Terminal(name)
+
+
+def makeInvalidLhsNameFormatError(rule):
+    return InvalidLhsNameError(rule)
+
+
+def makeInvalidLhsAltNameFormatError(rule):
+    return InvalidLhsAltNameError(rule)
+
+
+def makeDuplicateLhsError(rule):
+    return DuplicateLhsError(rule)


### PR DESCRIPTION
This pull request should implement the following validations

- LHS Non-terminal names must start with a lower-case letter, and may contain upper or lower case letters, numbers, and underscore.
- The resolved names for all LHS rules must be unique.
- User supplied names on for LHS symbols must start with a capital letter, and may contain upper or lower case letters, numbers, and underscore.