### PR TITLE
validate semantic section

### DIFF
--- a/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_code_fragments.py
+++ b/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_code_fragments.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from .parse_target_locator import TargetLocator, parse_target_locator, InvalidTargetLocatorError
+from .parse_target_locator import TargetLocator, parse_target_locator
 from plcc.load_spec.load_rough_spec.parse_lines import Line
 from plcc.load_spec.load_rough_spec.parse_blocks import Block
 from plcc.load_spec.load_rough_spec.parse_dividers import Divider
@@ -19,7 +19,7 @@ class CodeFragmentParser:
         self.lines_and_blocks = lines_and_blocks
         self.codeFragmentList = []
         self.targetLocator = None
-        self.targetLocator_regex = r'^(\w+)(?::([a-z]+))?\s*(?:#.*)?$'
+        self.targetLocator_regex = r'^(.+?)(?::([a-z]+))?\s*(?:#.*)?$'
 
     def parse(self):
         for obj in self.lines_and_blocks:
@@ -53,10 +53,7 @@ class CodeFragmentParser:
         if self.targetLocator != None:
             raise DuplicateTargetLocatorError(line.string)
         else:
-            if re.match(self.targetLocator_regex, line.string):
-                self.targetLocator = parse_target_locator(line, self.targetLocator_regex)
-            else:
-                raise InvalidTargetLocatorError(line)
+            self.targetLocator = parse_target_locator(line, self.targetLocator_regex)
 
 
     def _isCommentOrBlank(self, obj_str):

--- a/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_code_fragments_test.py
+++ b/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_code_fragments_test.py
@@ -15,11 +15,6 @@ def test_consecutive():
         CodeFragment(make_target_locator(lines_and_blocks[0], 'Class', 'init'), make_block()),
         CodeFragment(make_target_locator(lines_and_blocks[2], 'Main', None), make_block())]
 
-def test_invalid_target_locator_syntax():
-    lines_and_blocks = [make_line('`'), make_block()]
-    with raises(InvalidTargetLocatorError):
-        parse_code_fragments(lines_and_blocks)
-
 def test_input_must_be_Lines_and_Blocks():
     invalid_input = ["Only Lines and Dividers Work!", make_line('Class'), make_block()]
     with raises(TypeError):

--- a/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_target_locator.py
+++ b/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_target_locator.py
@@ -8,7 +8,7 @@ class TargetLocator:
     className: str
     modifier: str = None
 
-def parse_target_locator(line, regex=r'^(\w+)(?::([a-z]+))?\s*(?:#.*)?$'):
+def parse_target_locator(line, regex=r'^(.+?)(?::([a-z]+))?\s*(?:#.*)?$'):
     match = re.match(regex, line.string)
     if match:
         name, modifier = match.group(1), match.group(2) or None

--- a/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_target_locator_test.py
+++ b/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_target_locator_test.py
@@ -6,9 +6,9 @@ def test_ignore_EOL_comments():
     line = make_line('Class:init #comment')
     assert parse_target_locator(line) == TargetLocator(line, 'Class', 'init')
 
-def test_requires_colon():
-    with raises(InvalidTargetLocatorError):
-        targetLocator = parse_target_locator(make_line('Class init'))
+def test_className_accepts_any_character():
+    line = make_line('1*~=^RandomStuff')
+    assert parse_target_locator(line) == TargetLocator(line, '1*~=^RandomStuff', None)
 
 def test_modifier():
     lines = [make_line('Class:init'), make_line('Class:modifier')]

--- a/src/plcc/load_spec/validate_spec/validate_semantic_spec/__init__.py
+++ b/src/plcc/load_spec/validate_spec/validate_semantic_spec/__init__.py
@@ -1,0 +1,3 @@
+from .validate_semantic_spec import validate_semantic_spec
+
+from ...load_rough_spec.parse_lines import Line, parse_lines

--- a/src/plcc/load_spec/validate_spec/validate_semantic_spec/validate_semantic_spec.py
+++ b/src/plcc/load_spec/validate_spec/validate_semantic_spec/validate_semantic_spec.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from ...load_rough_spec.parse_lines import Line, parse_lines
+from ...parse_spec.parse_semantic_spec import SemanticSpec, CodeFragment
+import re
+
+@dataclass
+class InvalidClassNameError:
+    line: Line
+    message: str
+
+def validate_semantic_spec(semanticSpec: SemanticSpec):
+    return SemanticValidator(semanticSpec).validate()
+
+class SemanticValidator:
+    def __init__(self, semanticSpec: SemanticSpec):
+        self.semanticSpec = semanticSpec
+        self.errorList = []
+
+    def validate(self) -> list:
+        if (len(self.semanticSpec.codeFragmentList) == 0):
+            return self.errorList
+
+        for codeFragment in self.semanticSpec.codeFragmentList:
+            self._checkTargetLocatorClassName(codeFragment)
+
+        return self.errorList
+
+    def _checkTargetLocatorClassName(self, codeFragment: CodeFragment):
+        if not re.match(r'^[A-Z][A-Za-z0-9_]*$', codeFragment.targetLocator.className):
+            self.errorList.append(InvalidClassNameError(codeFragment.targetLocator.line,
+            f"Invalid name format for ClassName {codeFragment.targetLocator.className}, (Must start with an upper case letter, and may contain upper or lower case letters, numbers, and underscores)."))
+
+
+
+
+
+

--- a/src/plcc/load_spec/validate_spec/validate_semantic_spec/validate_semantic_spec_test.py
+++ b/src/plcc/load_spec/validate_spec/validate_semantic_spec/validate_semantic_spec_test.py
@@ -1,0 +1,89 @@
+from pytest import raises, mark, fixture
+from .validate_semantic_spec import InvalidClassNameError, validate_semantic_spec
+from ...parse_spec.parse_semantic_spec import SemanticSpec, parse_semantic_spec
+from ...load_rough_spec.parse_lines import Line, parse_lines
+from ...load_rough_spec.parse_dividers import Divider
+from ...load_rough_spec.parse_blocks import Block
+
+
+
+def test_valid_names_no_errors():
+    assertValidClassNames(["Class","CLASS","C_lass_","C123","C", "ClaSs", "C_la55"])
+
+def test_no_code_fragments_no_errors():
+    semanticSpec = makeSemanticSpec([])
+    errors = validate_semantic_spec(semanticSpec)
+    assert len(errors) == 0
+
+def test_begin_lowercase_format_error():
+    assertInvalidClassName("startsLowerCase")
+
+def test_begin_number_format_error():
+    assertInvalidClassName("12MustStartUppercase")
+
+def test_whitespace_name_format_error():
+    assertInvalidClassName("White Space")
+
+def test_multiple_errors_all_counted():
+    assertMultipleInvalidClassNames(["123StartsWithNumbers", "notuppercase", "InvalidChar`", "Invalid space"])
+
+def test_valid_and_invalid_names():
+    semanticSpec = makeSemanticSpec([makeLine("Class"), makeBlock(), makeLine("invalid"), makeBlock()])
+    errors = validate_semantic_spec(semanticSpec)
+    assert len(errors) == 1
+    assert errors[0] == makeInvalidClassNameError("invalid")
+
+def assertValidClassNames(names: list[str]):
+    for name in names:
+        assertValidClassName(name)
+
+def assertValidClassName(name: str):
+    semanticSpec = makeSemanticSpec([makeLine(name), makeBlock()])
+    errors = validate_semantic_spec(semanticSpec)
+    assert len(errors) == 0
+
+def assertInvalidClassName(name: str):
+    semanticSpec = makeSemanticSpec([makeLine(name), makeBlock()])
+    errors = validate_semantic_spec(semanticSpec)
+    assert len(errors) == 1
+    assert errors[0] == makeInvalidClassNameError(name)
+
+def assertMultipleInvalidClassNames(strings):
+    lines_and_blocks = makeLinesAndBlocksFromStrings(strings)
+    semanticSpec = makeSemanticSpec(lines_and_blocks)
+    errors = validate_semantic_spec(semanticSpec)
+    for i, obj in enumerate(lines_and_blocks):
+        if type(obj) is Block:
+            return
+        assert errors[i] == makeInvalidClassNameError(obj.string)
+    else: # pragma: no cover
+        pass
+
+
+def makeLinesAndBlocksFromStrings(strings: list[str]) -> list[Line | Block]:
+    lines_and_blocks = []
+    for string in strings:
+        lines_and_blocks.append(makeLine(string))
+        lines_and_blocks.append(makeBlock())
+    return lines_and_blocks
+
+def makeInvalidClassNameError(name: str):
+    return InvalidClassNameError(
+        makeLine(name),
+        f"Invalid name format for ClassName {name}, (Must start with an upper case letter, and may contain upper or lower case letters, numbers, and underscores).")
+
+def makeSemanticSpec(linesAndBlocks: list[Line | Block]):
+    return parse_semantic_spec([makeDivider('Java', 'Java', makeLine("%"))] + linesAndBlocks)
+
+def makeLine(string, lineNumber=1, file=None):
+    return Line(string, lineNumber, file)
+
+def makeBlock():
+    return  Block(list(parse_lines('''\
+%%%
+block
+%%%
+''')))
+
+def makeDivider(tool, language, line):
+    return Divider(tool=tool, language=language, line=line)


### PR DESCRIPTION
feat: add validate_semantic_spec

Validates a given SemanticSpec object and returns a errorList.

---

* Closes #23 

---

Co-authored-by: Michael Banerjee <michaelbanerjee10@gmail.com>