### PR TITLE
change call to validate_syntactic_spec to include necessary components

### DIFF
--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_rhs.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_rhs.py
@@ -1,18 +1,21 @@
+from ...parse_spec.parse_lexical_spec import LexicalSpec
 from ...parse_spec.parse_syntactic_spec import (
     SyntacticSpec,
 )
 
 
-def validate_rhs(syntacticSpec: SyntacticSpec):
-    return SyntacticRhsValidator(syntacticSpec).validate()
+def validate_rhs(syntacticSpec: SyntacticSpec, lexicalSpec: LexicalSpec, nonTerminals: set()):
+    return SyntacticRhsValidator(syntacticSpec, lexicalSpec, nonTerminals).validate()
 
 
 class SyntacticRhsValidator:
     spec: SyntacticSpec
 
-    def __init__(self, syntacticSpec: SyntacticSpec):
-        self.spec = syntacticSpec
+    def __init__(self, syntacticSpec: SyntacticSpec, lexicalSpec: LexicalSpec, nonTerminals: set()):
+        self.syntacticSpec = syntacticSpec
+        self.lexicalSpec = lexicalSpec
         self.errorList = []
+        self.nonTerminals = set()
 
     def validate(self):
         pass

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_syntactic_spec.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_syntactic_spec.py
@@ -2,20 +2,23 @@ from ...parse_spec.parse_syntactic_spec import (
     SyntacticSpec,
     SyntacticRule,
 )
+from ...parse_spec.parse_lexical_spec import LexicalSpec
 from .validate_lhs import validate_lhs
 from .validate_rhs import validate_rhs
 
 
-def validate_syntactic_spec(syntacticSpec: SyntacticSpec):
-    return SyntacticValidator(syntacticSpec).validate()
+def validate_syntactic_spec(syntacticSpec: SyntacticSpec, lexicalSpec: LexicalSpec):
+    return SyntacticValidator(syntacticSpec, lexicalSpec).validate()
 
 
 class SyntacticValidator:
+    lexicalSpec: LexicalSpec
     syntacticSpec: SyntacticSpec
     rule: SyntacticRule
 
-    def __init__(self, syntacticSpec: SyntacticSpec):
+    def __init__(self, syntacticSpec: SyntacticSpec, lexicalSpec: LexicalSpec):
         self.syntacticSpec = syntacticSpec
+        self.lexicalSpec = lexicalSpec
         self.errorList = []
         self.nonTerminals = set()
 
@@ -32,4 +35,5 @@ class SyntacticValidator:
         self.nonTerminals = non_terminal_set
 
     def _validateRhs(self):
-        _ = validate_rhs(self.syntacticSpec)
+        _ = validate_rhs(self.syntacticSpec,
+                         self.lexicalSpec, self.nonTerminals)

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_syntactic_spec_test.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_syntactic_spec_test.py
@@ -3,6 +3,7 @@ from typing import List
 
 from ...load_rough_spec.parse_lines import Line
 from .validate_syntactic_spec import validate_syntactic_spec
+from ...parse_spec.parse_lexical_spec import LexicalSpec
 from ...parse_spec.parse_syntactic_spec import (
     SyntacticRule,
     SyntacticSpec,
@@ -19,22 +20,23 @@ from .errors import (
 
 def test_empty_no_errors():
     syntacticSpec = makeSyntacticSpec([])
-    errors = validate_syntactic_spec(syntacticSpec)
+    errors = validate(syntacticSpec)
     assert len(errors) == 0
 
 
 def test_None_no_errors():
     syntacticSpec = makeSyntacticSpec(None)
-    errors = validate_syntactic_spec(syntacticSpec)
+    errors = validate(syntacticSpec)
     assert len(errors) == 0
 
 
 def test_valid_line_no_errors():
     valid_line = makeLine("<sentence> ::= WORD")
-    errors = validate_syntactic_spec(
+    errors = validate(
         [
             makeSyntacticRule(
-                valid_line, makeLhsNonTerminal("sentence"), [makeTerminal("WORD")]
+                valid_line, makeLhsNonTerminal("sentence"), [
+                    makeTerminal("WORD")]
             )
         ]
     )
@@ -52,13 +54,13 @@ def test_distinct_resolved_name():
         makeLhsNonTerminal("sentence", "Question"),
         [makeTerminal("WORD")],
     )
-    errors = validate_syntactic_spec([line_answer, line_question])
+    errors = validate([line_answer, line_question])
     assert len(errors) == 0
 
 
 def test_valid_lhs_alt_name():
     valid_line = makeLine("<sentence>:Name_Version_1 ::= WORD")
-    errors = validate_syntactic_spec(
+    errors = validate(
         [
             makeSyntacticRule(
                 valid_line,
@@ -74,10 +76,11 @@ def test_number_lhs_terminal():
     invalid_nonterminal = makeLine("<1sentence> ::= WORD")
     spec = [
         makeSyntacticRule(
-            invalid_nonterminal, makeLhsNonTerminal("1sentence"), [makeTerminal("WORD")]
+            invalid_nonterminal, makeLhsNonTerminal(
+                "1sentence"), [makeTerminal("WORD")]
         )
     ]
-    errors = validate_syntactic_spec(spec)
+    errors = validate(spec)
     assert len(errors) == 1
     assert errors[0] == makeInvalidLhsNameFormatError(spec[0])
 
@@ -86,10 +89,11 @@ def test_capital_lhs_terminal():
     capital_lhs_name = makeLine("<Sentence> ::= WORD")
     spec = [
         makeSyntacticRule(
-            capital_lhs_name, makeLhsNonTerminal("Sentence"), [makeTerminal("WORD")]
+            capital_lhs_name, makeLhsNonTerminal(
+                "Sentence"), [makeTerminal("WORD")]
         )
     ]
-    errors = validate_syntactic_spec(spec)
+    errors = validate(spec)
     assert len(errors) == 1
     assert errors[0] == makeInvalidLhsNameFormatError(spec[0])
 
@@ -103,7 +107,7 @@ def test_undercase_lhs_alt_name():
             [makeTerminal("WORD")],
         )
     ]
-    errors = validate_syntactic_spec(spec)
+    errors = validate(spec)
     assert len(errors) == 1
     assert errors[0] == makeInvalidLhsAltNameFormatError(spec[0])
 
@@ -117,7 +121,7 @@ def test_underscore_lhs_alt_name():
             [makeTerminal("WORD")],
         )
     ]
-    errors = validate_syntactic_spec(spec)
+    errors = validate(spec)
     assert len(errors) == 1
     assert errors[0] == makeInvalidLhsAltNameFormatError(spec[0])
 
@@ -135,7 +139,7 @@ def test_duplicate_lhs_name():
         [makeTerminal("WORD")],
     )
     spec = [rule_1, rule_2]
-    errors = validate_syntactic_spec(spec)
+    errors = validate(spec)
     assert len(errors) == 1
     assert errors[0] == makeDuplicateLhsError(spec[1])
 
@@ -152,7 +156,7 @@ def test_duplicate_lhs_alt_name():
         [makeTerminal("WORD")],
     )
     spec = [rule_1, rule_2]
-    errors = validate_syntactic_spec(spec)
+    errors = validate(spec)
     assert len(errors) == 1
     assert errors[0] == makeDuplicateLhsError(spec[1])
 
@@ -169,9 +173,13 @@ def test_duplicate_resolved_name():
         [makeTerminal("WORD")],
     )
     spec = [alt_name, non_terminal_name]
-    errors = validate_syntactic_spec(spec)
+    errors = validate(spec)
     assert len(errors) == 1
     assert errors[0] == makeDuplicateLhsError(spec[1])
+
+
+def validate(syntacticSpec: SyntacticSpec, lexicalSpec: LexicalSpec = []):
+    return validate_syntactic_spec(syntacticSpec, lexicalSpec)
 
 
 def makeSyntacticSpec(ruleList=None):


### PR DESCRIPTION
Validations that ensure existence of terminals in lexical specification need access to lexical specification. Plumbing re-done to accomodate this change, as well as sending lhs non-terminals list to SyntacticRhsValidator to make ensuring valid rhs non-terminals possible.