### PR TITLE
Validate RHS Resolved Names and Separators

### DIFF
--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/__init__.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/__init__.py
@@ -10,7 +10,9 @@ from .errors import (
     ValidationError,
     InvalidLhsNameError,
     InvalidLhsAltNameError,
+    InvalidRepeatingRuleSeparatorError,
     DuplicateLhsError,
+    DuplicateRhsSymbolError
 )
 from ...load_rough_spec.parse_lines import Line, parse_lines
 from ...load_rough_spec.parse_includes import Include, parse_includes

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/errors.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/errors.py
@@ -22,10 +22,23 @@ class InvalidLhsAltNameError(ValidationError):
         self.message = f"Invalid LHS alternate name format for rule: '{
             rule.line.string}' (must start with a upper-case letter, and may contain upper or lower case letters, numbers and/or underscore) on line: {rule.line.number}"
 
+@dataclass
+class InvalidRepeatingRuleSeparatorError(ValidationError):
+    def __init__(self, rule):
+        super().__init__(rule)
+        self.message = f"Invalid RHS separator symbol for rule: '{
+            rule.line.string}' (repeating rule separators must be terminals) on line: {rule.line.number}"
 
 @dataclass
 class DuplicateLhsError(ValidationError):
     def __init__(self, rule):
         super().__init__(rule)
         self.message = f"Duplicate lhs name: '{
+                rule.line.string}' on line: {rule.line.number}"
+
+@dataclass
+class DuplicateRhsSymbolError(ValidationError):
+    def __init__(self, rule):
+        super().__init__(rule)
+        self.message = f"Duplicate rhs name: '{
                 rule.line.string}' on line: {rule.line.number}"

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_rhs.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_rhs.py
@@ -1,12 +1,18 @@
 from ...parse_spec.parse_lexical_spec import LexicalSpec
 from ...parse_spec.parse_syntactic_spec import (
     SyntacticSpec,
+    CapturingSymbol,
+    Terminal,
+    RepeatingSyntacticRule
+)
+from .errors import (
+    DuplicateRhsSymbolError,
+    ValidationError,
+    InvalidRepeatingRuleSeparatorError
 )
 
-
 def validate_rhs(syntacticSpec: SyntacticSpec, lexicalSpec: LexicalSpec, nonTerminals: set()):
-    return SyntacticRhsValidator(syntacticSpec, lexicalSpec, nonTerminals).validate()
-
+    return SyntacticRhsValidator(syntacticSpec.copy(), lexicalSpec, nonTerminals).validate()
 
 class SyntacticRhsValidator:
     spec: SyntacticSpec
@@ -17,5 +23,53 @@ class SyntacticRhsValidator:
         self.errorList = []
         self.nonTerminals = set()
 
-    def validate(self):
-        pass
+    def validate(self) -> tuple[list[ValidationError], set[str]]:
+        while len(self.syntacticSpec) > 0:
+            self.rule = self.syntacticSpec.pop(0)
+            self._checkLine()
+        return self.errorList, self.nonTerminals
+
+    def _checkLine(self):
+        self._validateResolvedNames()
+        if self._isRepeatingRule():
+            self._validateSeparator()
+
+    def _validateResolvedNames(self):
+        for resolvedName in self._getResolvedNames():
+            if resolvedName in self.nonTerminals:
+                self._appendDuplicateRhsSymbolError()
+            self.nonTerminals.add(resolvedName)
+
+    def _getResolvedNames(self) -> list[str]:
+        resolvedNames = []
+        for symbol in self.rule.rhsSymbolList:
+            if self._isCapturingSymbol(symbol):
+                self._addResolvedNameToList(symbol, resolvedNames)
+        return resolvedNames
+
+    def _addResolvedNameToList(self, symbol, resolvedNames):
+        resolvedName = self._getResolvedName(symbol)
+        resolvedNames.append(resolvedName)
+
+    def _getResolvedName(self, symbol) -> str:
+        return symbol.altName if symbol.altName else symbol.name #TODO was .captialize() at end
+
+    def _isRepeatingRule(self):
+        return True if isinstance(self.rule, RepeatingSyntacticRule) else False
+
+    def _validateSeparator(self):
+        if not self._isSeparatorTerminal():
+            self._appendInvalidRepeatingRuleSeparatorError()
+
+    def _isSeparatorTerminal(self):
+        return True if isinstance(self.rule.separator, Terminal) else False
+
+    def _isCapturingSymbol(self, symbol):
+        return True if isinstance(symbol, CapturingSymbol) else False
+
+    def _appendInvalidRepeatingRuleSeparatorError(self):
+        self.errorList.append(InvalidRepeatingRuleSeparatorError(self.rule))
+
+    def _appendDuplicateRhsSymbolError(self):
+        self.errorList.append(DuplicateRhsSymbolError(self.rule))
+

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_rhs.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_rhs.py
@@ -52,7 +52,7 @@ class SyntacticRhsValidator:
         resolvedNames.append(resolvedName)
 
     def _getResolvedName(self, symbol) -> str:
-        return symbol.altName if symbol.altName else symbol.name #TODO was .captialize() at end
+        return symbol.altName if symbol.altName else symbol.name
 
     def _isRepeatingRule(self):
         return True if isinstance(self.rule, RepeatingSyntacticRule) else False

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_syntactic_spec.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_syntactic_spec.py
@@ -26,6 +26,7 @@ class SyntacticValidator:
         if not self.syntacticSpec:
             return self.errorList
         self._validateLhs()
+        self._validateRhs()
         return self.errorList
 
     def _validateLhs(self):
@@ -35,5 +36,8 @@ class SyntacticValidator:
         self.nonTerminals = non_terminal_set
 
     def _validateRhs(self):
-        _ = validate_rhs(self.syntacticSpec,
-                         self.lexicalSpec, self.nonTerminals)
+        rhs_error_list, non_terminal_set = validate_rhs(self.syntacticSpec, self.lexicalSpec, self.nonTerminals)
+        if rhs_error_list:
+            self.errorList.extend(rhs_error_list)
+        self.nonTerminals.update(non_terminal_set)
+

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_syntactic_spec_test.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_syntactic_spec_test.py
@@ -263,7 +263,21 @@ def test_alt_names_and_names_are_considered_duplicate():
     assert len(errors) == 1
     assert errors[0] == makeDuplicateRhsSymbolError(spec[1])
 
-def test_invalid_non_terminal_separator():
+def test_valid_separator():
+    line = makeLine("<noun> **= WORD WORD +WORD")
+    terminal = makeTerminal("WORD")
+    spec = [
+        makeRepeatingSyntacticRule(
+            line,
+            makeLhsNonTerminal("noun"),
+            [terminal, terminal],
+            separator=makeTerminal("WORD")
+        )
+    ]
+    errors = validate(spec)
+    assert len(errors) == 0
+
+def test_invalid_rhs_non_terminal_separator():
     line_1 = makeLine("<noun> **= WORD WORD +<sentence> WORD")
     line_2 = makeLine("<sentence> ::= WORD")
     terminal = makeTerminal("WORD")
@@ -284,30 +298,17 @@ def test_invalid_non_terminal_separator():
     assert len(errors) == 1
     assert errors[0] == makeInvalidRepeatingRuleSeparatorError(spec[1])
 
-
-def makeRepeatingSyntacticRule(
-    line: Line,
-    lhs: LhsNonTerminal,
-    rhsSymbolList: List[Symbol],
-    separator: Terminal | None = None,
-):
-    return RepeatingSyntacticRule(line, lhs, rhsSymbolList, separator)
-
 def validate(syntacticSpec: SyntacticSpec, lexicalSpec: LexicalSpec = []):
     return validate_syntactic_spec(syntacticSpec, lexicalSpec)
-
 
 def makeSyntacticSpec(ruleList=None):
     return SyntacticSpec(ruleList)
 
-
 def makeSyntacticRule(line: Line, lhs: LhsNonTerminal, rhsList: List[Symbol]):
     return SyntacticRule(line, lhs, rhsList)
 
-
 def makeLine(string, lineNumber=1, file=None):
     return Line(string, lineNumber, file)
-
 
 def makeLhsNonTerminal(name: str | None, altName: str | None = None):
     return LhsNonTerminal(name, altName)
@@ -324,14 +325,19 @@ def makeInvalidRepeatingRuleSeparatorError(rule):
 def makeTerminal(name: str | None):
     return Terminal(name)
 
-
 def makeInvalidLhsNameFormatError(rule):
     return InvalidLhsNameError(rule)
-
 
 def makeInvalidLhsAltNameFormatError(rule):
     return InvalidLhsAltNameError(rule)
 
-
 def makeDuplicateLhsError(rule):
     return DuplicateLhsError(rule)
+
+def makeRepeatingSyntacticRule(
+    line: Line,
+    lhs: LhsNonTerminal,
+    rhsSymbolList: List[Symbol],
+    separator: Terminal | None = None,
+):
+    return RepeatingSyntacticRule(line, lhs, rhsSymbolList, separator)

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_syntactic_spec_test.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_syntactic_spec_test.py
@@ -6,15 +6,19 @@ from .validate_syntactic_spec import validate_syntactic_spec
 from ...parse_spec.parse_lexical_spec import LexicalSpec
 from ...parse_spec.parse_syntactic_spec import (
     SyntacticRule,
+    RepeatingSyntacticRule,
     SyntacticSpec,
     Symbol,
     LhsNonTerminal,
+    RhsNonTerminal,
     Terminal,
 )
 from .errors import (
     InvalidLhsNameError,
     InvalidLhsAltNameError,
+    InvalidRepeatingRuleSeparatorError,
     DuplicateLhsError,
+    DuplicateRhsSymbolError
 )
 
 
@@ -178,6 +182,117 @@ def test_duplicate_resolved_name():
     assert errors[0] == makeDuplicateLhsError(spec[1])
 
 
+def test_valid_rhs_alt_name():
+    line_1 = makeLine("<word> ::= WORD WORD")
+    line_2 = makeLine("<sentence> ::= <word>altName WORD WORD")
+    terminal = makeTerminal("WORD")
+    spec = [
+        makeSyntacticRule(
+            line_1,
+            makeLhsNonTerminal("word"),
+            [terminal, terminal]
+        ),
+        makeSyntacticRule(
+            line_2,
+            makeLhsNonTerminal("sentence"),
+            [makeRhsNonTerminal("word", "altName"), terminal, terminal]
+        )
+    ]
+    errors = validate(spec)
+    assert len(errors) == 0
+
+
+def test_duplicate_rhs_names():
+    line_1 = makeLine("<word> ::= WORD WORD")
+    line_2 = makeLine("<sentence> ::= <word>altName <word>altName WORD")
+    non_terminal = makeRhsNonTerminal("word", "altName")
+    terminal = makeTerminal("WORD")
+    spec = [
+        makeSyntacticRule(
+            line_1,
+            makeLhsNonTerminal("word"),
+            [terminal, terminal]
+        ),
+        makeSyntacticRule(
+            line_2,
+            makeLhsNonTerminal("sentence"),
+            [non_terminal, non_terminal, makeTerminal("WORD")]
+        )
+    ]
+    errors = validate(spec)
+    assert len(errors) == 1
+    assert errors[0] == makeDuplicateRhsSymbolError(spec[1])
+
+
+def test_distinct_rhs_names():
+    line_1 = makeLine("<word> ::= WORD WORD")
+    line_2 = makeLine("<sentence> ::= <word>altName <word>altName2 WORD")
+    terminal = makeTerminal("WORD")
+    spec = [
+        makeSyntacticRule(
+            line_1,
+            makeLhsNonTerminal("word"),
+            [terminal, terminal]
+        ),
+        makeSyntacticRule(
+            line_2,
+            makeLhsNonTerminal("sentence"),
+            [makeRhsNonTerminal("word", "altName"), makeRhsNonTerminal("word", "altName2"), makeTerminal("WORD")]
+        )
+    ]
+    errors = validate(spec)
+    assert len(errors) == 0
+
+def test_alt_names_and_names_are_considered_duplicate():
+    line_1 = makeLine("<word> ::= <word> <sentence>word")
+    line_2 = makeLine("<sentence> ::= WORD")
+    terminal = makeTerminal("WORD")
+    spec = [
+        makeSyntacticRule(
+            line_1,
+            makeLhsNonTerminal("word"),
+            [makeRhsNonTerminal("word"), makeRhsNonTerminal("sentence", "word")]
+        ),
+        makeSyntacticRule(
+            line_2,
+            makeLhsNonTerminal("sentence"),
+            [terminal]
+        )
+    ]
+    errors = validate(spec)
+    assert len(errors) == 1
+    assert errors[0] == makeDuplicateRhsSymbolError(spec[1])
+
+def test_invalid_non_terminal_separator():
+    line_1 = makeLine("<noun> **= WORD WORD +<sentence> WORD")
+    line_2 = makeLine("<sentence> ::= WORD")
+    terminal = makeTerminal("WORD")
+    spec = [
+        makeRepeatingSyntacticRule(
+            line_1,
+            makeLhsNonTerminal("noun"),
+            [terminal, terminal],
+            separator=makeRhsNonTerminal("sentence")
+        ),
+        makeSyntacticRule(
+            line_2,
+            makeLhsNonTerminal("sentence"),
+            [terminal]
+        )
+    ]
+    errors = validate(spec)
+    assert len(errors) == 1
+    assert errors[0] == makeInvalidRepeatingRuleSeparatorError(spec[1])
+
+
+def makeRepeatingSyntacticRule(
+    line: Line,
+    lhs: LhsNonTerminal,
+    rhsSymbolList: List[Symbol],
+    separator: Terminal | None = None,
+):
+    return RepeatingSyntacticRule(line, lhs, rhsSymbolList, separator)
+
 def validate(syntacticSpec: SyntacticSpec, lexicalSpec: LexicalSpec = []):
     return validate_syntactic_spec(syntacticSpec, lexicalSpec)
 
@@ -197,6 +312,14 @@ def makeLine(string, lineNumber=1, file=None):
 def makeLhsNonTerminal(name: str | None, altName: str | None = None):
     return LhsNonTerminal(name, altName)
 
+def makeRhsNonTerminal(name: str | None, altName: str | None = None):
+    return RhsNonTerminal(name, altName)
+
+def makeDuplicateRhsSymbolError(rule):
+    return DuplicateRhsSymbolError(rule)
+
+def makeInvalidRepeatingRuleSeparatorError(rule):
+    return InvalidRepeatingRuleSeparatorError(rule)
 
 def makeTerminal(name: str | None):
     return Terminal(name)


### PR DESCRIPTION
feat: add _validateResolvedNames() and _validateSeparator()

Within a rule, the resolved names for all RHS symbols must be unique.
The separator for a repetition rule must be a terminal.

---
* Closes #35 
---

Co-authored-by: Michael Banerjee <michaelbanerjee10@gmail.com>