### PR TITLE
refactor: remove ValidationError3

### DIFF
--- a/src/plcc/load_spec/errors.py
+++ b/src/plcc/load_spec/errors.py
@@ -1,4 +1,4 @@
-from plcc.load_spec.structs import Line
+from plcc.load_spec.structs import Line, SyntacticRule
 
 
 from dataclasses import dataclass
@@ -50,71 +50,75 @@ class InvalidClassNameError:
 
 
 @dataclass
-class ValidationError3():
+class InvalidLhsNameError(ValidationError):
     def __init__(self, rule):
-        self.rule = rule
+        super().__init__(
+            line=rule.line,
+            message=f"Invalid LHS name format for rule: '{rule.line.string}' (must start with a lower-case letter, and may contain upper or lower case letters, numbers and/or underscore) on line: {rule.line.number}"
+        )
 
 
 @dataclass
-class InvalidLhsNameError(ValidationError3):
+class InvalidLhsAltNameError(ValidationError):
     def __init__(self, rule):
-        super().__init__(rule)
-        self.message = f"Invalid LHS name format for rule: '{rule.line.string}' (must start with a lower-case letter, and may contain upper or lower case letters, numbers and/or underscore) on line: {rule.line.number}"
+        super().__init__(
+            line=rule.line,
+            message=f"Invalid LHS alternate name format for rule: '{rule.line.string}' (must start with a upper-case letter, and may contain upper or lower case letters, numbers and/or underscore) on line: {rule.line.number}"
+        )
 
 
 @dataclass
-class InvalidLhsAltNameError(ValidationError3):
+class DuplicateLhsError(ValidationError):
     def __init__(self, rule):
-        super().__init__(rule)
-        self.message = f"Invalid LHS alternate name format for rule: '{rule.line.string}' (must start with a upper-case letter, and may contain upper or lower case letters, numbers and/or underscore) on line: {rule.line.number}"
+        super().__init__(
+            line=rule.line,
+            message=f"Duplicate lhs name: '{rule.line.string}' on line: {rule.line.number}"
+        )
 
 
 @dataclass
-class DuplicateLhsError(ValidationError3):
+class InvalidRhsNameError(ValidationError):
     def __init__(self, rule):
-        super().__init__(rule)
-        self.message = f"Duplicate lhs name: '{
-            rule.line.string}' on line: {rule.line.number}"
+        super().__init__(
+            line=rule.line,
+            message=f"Invalid RHS name format for rule: '{rule.line.string}' (must start with a lower-case letter, and may contain upper or lower case letters, numbers, and underscore.) on line: {rule.line.number}"
+        )
 
 
 @dataclass
-class InvalidRhsNameError(ValidationError3):
+class InvalidRhsAltNameError(ValidationError):
     def __init__(self, rule):
-        super().__init__(rule)
-        self.message = f"Invalid RHS name format for rule: '{
-            rule.line.string}' (must start with a lower-case letter, and may contain upper or lower case letters, numbers, and underscore.) on line: {rule.line.number}"
+        super().__init__(
+            line=rule.line,
+            message = f"Invalid RHS alternate name format for rule: '{rule.line.string}' (must start with a lower case letter, and may contain upper or lower case letters, numbers, and underscore. on line: {rule.line.number}"
+        )
 
 
 @dataclass
-class InvalidRhsAltNameError(ValidationError3):
+class InvalidRhsTerminalError(ValidationError):
     def __init__(self, rule):
-        super().__init__(rule)
-        self.message = f"Invalid RHS alternate name format for rule: '{
-            rule.line.string}' (must start with a lower case letter, and may contain upper or lower case letters, numbers, and underscore. on line: {rule.line.number}"
+        super().__init__(
+            line=rule.line,
+            message=f"Invalid RHS alternate name format for rule: '{rule.line.string}' (upper-case letters, numbers, and underscore and cannot start with a number. on line: {rule.line.number}"
+        )
 
 
 @dataclass
-class InvalidRhsTerminalError(ValidationError3):
+class UndefinedTerminalError(ValidationError):
     def __init__(self, rule):
-        super().__init__(rule)
-        self.message = f"Invalid RHS alternate name format for rule: '{
-            rule.line.string}' (upper-case letters, numbers, and underscore and cannot start with a number. on line: {rule.line.number}"
+        super().__init__(
+            line=rule.line,
+            message=f"Undefined terminal for rule: '{rule.line.string}' on line: {rule.line.number}. All terminals must be defined in the lexical section of the grammar file."
+        )
 
 
 @dataclass
-class UndefinedTerminalError(ValidationError3):
+class InvalidRhsSeparatorTypeError(ValidationError):
     def __init__(self, rule):
-        super().__init__(rule)
-        self.message = f"Undefined terminal for rule: '{
-            rule.line.string}' on line: {rule.line.number}. All terminals must be defined in the lexical section of the grammar file."
-
-
-@dataclass
-class InvalidRhsSeparatorTypeError(ValidationError3):
-    def __init__(self, rule):
-        super().__init__(rule)
-        self.message = f"Invalid RHS separator, must be terminal: '{
-            rule.line.string}' "
+        super().__init__(
+            line=rule.line,
+            message=f"Invalid RHS separator, must be terminal: '{rule.line.string}'"
+        )
 
 
 @dataclass

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/__init__.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/__init__.py
@@ -1,4 +1,4 @@
-from ...errors import InvalidLhsAltNameError, InvalidLhsNameError, ValidationError3
+from ...errors import InvalidLhsAltNameError, InvalidLhsNameError, ValidationError
 from ...structs import Divider, Include, Line, SyntacticRule, SyntacticSpec
 from .validate_syntactic_spec import validate_syntactic_spec
 

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/check_ll1/check_ll1.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/check_ll1/check_ll1.py
@@ -1,12 +1,12 @@
 from .Grammar import Grammar
-from ....errors import ValidationError3
+from ....errors import ValidationError
 from .build_first_sets import build_first_sets
 from .build_follow_sets import build_follow_sets
 from .build_parsing_table import build_parsing_table
 from .check_parsing_table_for_ll1 import check_parsing_table_for_ll1
 
 
-def check_ll1(grammar: Grammar) -> list[ValidationError3]:
+def check_ll1(grammar: Grammar) -> list[ValidationError]:
     return LL1Checker(grammar).check()
 
 
@@ -14,7 +14,7 @@ class LL1Checker:
     def __init__(self, grammar: Grammar):
         self.grammar = grammar
 
-    def check(self) -> list[ValidationError3]:
+    def check(self) -> list[ValidationError]:
         # TODO: Check for left recursion (direct or indirect)
         # TODO: Check for non-left-refactored rules
         errors = self._checkll1()

--- a/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_lhs.py
+++ b/src/plcc/load_spec/validate_spec/validate_syntactic_spec/validate_lhs.py
@@ -1,6 +1,6 @@
 import re
 
-from ...errors import InvalidLhsAltNameError, InvalidLhsNameError, ValidationError3
+from ...errors import InvalidLhsAltNameError, InvalidLhsNameError, ValidationError
 from ...structs import (
     SyntacticSpec,
 )
@@ -21,7 +21,7 @@ class SyntacticLhsValidator:
         self.errorList = []
         self.nonTerminals = set()
 
-    def validate(self) -> tuple[list[ValidationError3], set[str]]:
+    def validate(self) -> tuple[list[ValidationError], set[str]]:
         while len(self.spec) > 0:
             self.rule = self.spec.pop(0)
             self._checkLine()


### PR DESCRIPTION
When I moved all errors to plcc/load_spec/errors.py I found 3 implementations of ValidationError. To allow the refactoring tool to work and make the move, I first renamed two of the implementations to ValidationError2 and ValidationError3. Once the move was made, I compared the implementations and found that the original and 2 were the same, so I renamed ValidationError2 (and all its references) to just ValidationError. Then I removed it leaving the original.

ValidationError3's implementation is different. It's constructor takes a different parameter. This commit removes ValidationError3 and has each of its subclass call the superclass constructor with the normal expected parameters. No changes are needed by client code except their import statements had to be adjusted to use ValidationError instead of ValidationError3.

Closes #79 