### PR TITLE
refactor: remove unused default parameters

### DIFF
--- a/src/plcc/load_spec/load_rough_spec/parse_includes.py
+++ b/src/plcc/load_spec/load_rough_spec/parse_includes.py
@@ -3,11 +3,8 @@ import re
 from plcc.load_spec.structs import Include
 
 
-def parse_includes(
-        lines,
-        pattern=re.compile(r'^%include\s+(?P<file>[^\0]+)$'),
-        Include=Include
-        ):
+def parse_includes(lines):
+    pattern=re.compile(r'^%include\s+(?P<file>[^\0]+)$')
     if lines is None:
         return
     for line in lines:

--- a/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_code_fragments.py
+++ b/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_code_fragments.py
@@ -15,7 +15,6 @@ class CodeFragmentParser:
         self.lines_and_blocks = lines_and_blocks
         self.codeFragmentList = []
         self.targetLocator = None
-        self.targetLocator_regex = r'^(.+?)(?::([a-z]+))?\s*(?:#.*)?$'
 
     def parse(self):
         for obj in self.lines_and_blocks:
@@ -49,7 +48,7 @@ class CodeFragmentParser:
         if self.targetLocator != None:
             raise DuplicateTargetLocatorError(line.string)
         else:
-            self.targetLocator = parse_target_locator(line, self.targetLocator_regex)
+            self.targetLocator = parse_target_locator(line)
 
 
     def _isCommentOrBlank(self, obj_str):

--- a/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_target_locator.py
+++ b/src/plcc/load_spec/parse_spec/parse_semantic_spec/parse_target_locator.py
@@ -2,7 +2,8 @@ import re
 
 from plcc.load_spec.structs import TargetLocator
 
-def parse_target_locator(line, regex=r'^(.+?)(?::([a-z]+))?\s*(?:#.*)?$'):
+def parse_target_locator(line):
+    regex=r'^(.+?)(?::([a-z]+))?\s*(?:#.*)?$'
     match = re.match(regex, line.string)
     if match:
         name, modifier = match.group(1), match.group(2) or None


### PR DESCRIPTION
In the beginning, all functions that used a regex accepted a default parameter as the regex. I thought it would be nice to allow these to be passed by the caller in case the syntax ever changed. For example...

```python
def parseTerminal(pattern=r'[A-Z_]+'):
    ...
```

This overcomplicates the function, and makes you wonder if there are any call sites that are passing a different regex.

These should be rewriting to something like the following:

```python
def parseTerminal():
    pattern = r'[A-Z_]+'
    ...
```

Closes #75 